### PR TITLE
Use stable gradle plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0-beta05' apply false
-    id 'com.android.library' version '7.4.0-beta05' apply false
+    id 'com.android.application' version '7.3.0' apply false
+    id 'com.android.library' version '7.3.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }


### PR DESCRIPTION
Betas are strictly tied to a particular Android Studio major release version