### PR TITLE
GattDevice rewrite

### DIFF
--- a/blex/src/main/java/se/hellsoft/blex/ChannelBluetoothGattCallback.kt
+++ b/blex/src/main/java/se/hellsoft/blex/ChannelBluetoothGattCallback.kt
@@ -1,0 +1,168 @@
+package se.hellsoft.blex
+
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.channels.ReceiveChannel
+import java.lang.IllegalStateException
+
+@Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
+class ChannelBluetoothGattCallback : BluetoothGattCallback() {
+    private val events = Channel<GattEvent>(BUFFERED)
+    val receiveEvents: ReceiveChannel<GattEvent> = events
+
+    private fun sendOrThrow(event: GattEvent) {
+        val result = events.trySend(event)
+        if (!result.isSuccess) {
+            throw IllegalStateException("Overflow or closed output: $result")
+        }
+    }
+
+    override fun onPhyUpdate(gatt: BluetoothGatt?, txPhy: Int, rxPhy: Int, status: Int) {
+        val phyUpdate = PhyUpdate(txPhy, rxPhy, status)
+        sendOrThrow(phyUpdate)
+    }
+
+    override fun onPhyRead(gatt: BluetoothGatt, txPhy: Int, rxPhy: Int, status: Int) {
+        val phyRead = PhyRead(txPhy, rxPhy, status)
+        sendOrThrow(phyRead)
+    }
+
+    override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+        val connectionChanged =
+            ConnectionChanged(status, ConnectionState.fromState(newState))
+        sendOrThrow(connectionChanged)
+    }
+
+    override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+        val servicesDiscovered = ServicesDiscovered(status)
+        sendOrThrow(servicesDiscovered)
+    }
+
+    override fun onCharacteristicRead(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray,
+        status: Int
+    ) {
+        val characteristicRead = CharacteristicRead(
+            GattCharacteristic(characteristic),
+            value,
+            status
+        )
+        sendOrThrow(characteristicRead)
+    }
+
+    override fun onCharacteristicWrite(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        status: Int
+    ) {
+        val characteristicWritten = CharacteristicWritten(
+            GattCharacteristic(characteristic),
+            status
+        )
+        sendOrThrow(characteristicWritten)
+    }
+
+    override fun onCharacteristicChanged(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray
+    ) {
+        val characteristicChanged = CharacteristicChanged(
+            GattCharacteristic(characteristic),
+            value
+        )
+        sendOrThrow(characteristicChanged)
+    }
+
+    override fun onDescriptorRead(
+        gatt: BluetoothGatt,
+        descriptor: BluetoothGattDescriptor,
+        status: Int,
+        value: ByteArray
+    ) {
+        val descriptorRead = DescriptorRead(
+            GattCharacteristic(descriptor.characteristic),
+            GattDescriptor(descriptor),
+            value,
+            status
+        )
+        sendOrThrow(descriptorRead)
+    }
+
+    override fun onDescriptorWrite(
+        gatt: BluetoothGatt,
+        descriptor: BluetoothGattDescriptor,
+        status: Int
+    ) {
+        val descriptorWritten = DescriptorWritten(
+            GattCharacteristic(descriptor.characteristic),
+            descriptor.uuid,
+            status
+        )
+        sendOrThrow(descriptorWritten)
+    }
+
+    override fun onCharacteristicRead(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        status: Int
+    ) {
+        val characteristicRead = CharacteristicRead(
+            GattCharacteristic(characteristic),
+            characteristic.value,
+            status
+        )
+        sendOrThrow(characteristicRead)
+    }
+
+    override fun onCharacteristicChanged(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic
+    ) {
+        val characteristicChanged = CharacteristicChanged(
+            GattCharacteristic(characteristic),
+            characteristic.value
+        )
+        sendOrThrow(characteristicChanged)
+    }
+
+    override fun onDescriptorRead(
+        gatt: BluetoothGatt,
+        descriptor: BluetoothGattDescriptor,
+        status: Int
+    ) {
+        val descriptorRead = DescriptorRead(
+            GattCharacteristic(descriptor.characteristic),
+            GattDescriptor(descriptor),
+            descriptor.value,
+            status
+        )
+        sendOrThrow(descriptorRead)
+    }
+
+    override fun onReliableWriteCompleted(gatt: BluetoothGatt?, status: Int) {
+        val reliableWriteCompleted = ReliableWriteCompleted(status)
+        sendOrThrow(reliableWriteCompleted)
+    }
+
+    override fun onReadRemoteRssi(gatt: BluetoothGatt?, rssi: Int, status: Int) {
+        val readRemoteRssi = ReadRemoteRssi(rssi, status)
+        sendOrThrow(readRemoteRssi)
+    }
+
+    override fun onMtuChanged(gatt: BluetoothGatt?, mtu: Int, status: Int) {
+        val mtuChanged = MtuChanged(mtu, status)
+        sendOrThrow(mtuChanged)
+    }
+
+    override fun onServiceChanged(gatt: BluetoothGatt) {
+        val serviceChanged = ServiceChanged
+        sendOrThrow(serviceChanged)
+    }
+}

--- a/blex/src/main/java/se/hellsoft/blex/GattDevice.kt
+++ b/blex/src/main/java/se/hellsoft/blex/GattDevice.kt
@@ -3,149 +3,56 @@ package se.hellsoft.blex
 import android.Manifest.permission.BLUETOOTH
 import android.Manifest.permission.BLUETOOTH_CONNECT
 import android.annotation.SuppressLint
-import android.bluetooth.*
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
 import android.content.Context
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresPermission
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeout
-import java.util.*
+import kotlinx.coroutines.withTimeoutOrNull
+import java.lang.IllegalStateException
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
 
-const val DEFAULT_GATT_TIMEOUT = 5000L
+val DEFAULT_GATT_TIMEOUT = 5.seconds
 
-/**
- * The wrapper for the system BluetoothGattDevice, which provides a safer API for performing GATT
- * operations.
- *
- * All operations are queued safely and this class can also safely be reused even after `close()`
- * have been called.
- */
-@Suppress("DEPRECATION", "unused", "MemberVisibilityCanBePrivate")
 @SuppressLint("InlinedApi")
-class GattDevice(
-    val bluetoothDevice: BluetoothDevice,
-    bufferCapacity: Int = DEFAULT_EVENT_BUFFER_CAPACITY,
-    private val logger: ((level: Int, message: String, throwable: Throwable?) -> Unit)? = null,
-) {
+interface GattDevice {
     companion object {
-        /**
-         * The default capacity for the events Flow.
-         */
-        const val DEFAULT_EVENT_BUFFER_CAPACITY = 10
-
-        /**
-         * The UUID for the standard Client Characteristic Configuration.
-         * This is usually used to enable/disable notifications on a characteristic.
-         */
         val ClientCharacteristicConfigurationID: UUID =
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     }
 
-    private val callback =
-        GattCallback(bufferCapacity) { gatt -> services = gatt.services.map { GattService(it) } }
-    private val mutex = Mutex()
-    private var bluetoothGatt: BluetoothGatt? = null
+    val connectionState: StateFlow<ConnectionState>
+    val services: StateFlow<List<GattService>>
 
-    val events = callback.events
-    val connectionState: Flow<ConnectionChanged> = callback.events.filterIsInstance()
-    var services: List<GattService> = emptyList()
-        internal set
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun connect(
-        context: Context,
-        autoConnect: Boolean = true,
-        transport: Int = BluetoothDevice.TRANSPORT_LE,
-        phy: Int = BluetoothDevice.PHY_LE_1M,
-    ): Flow<ConnectionChanged> {
-        return callback.events
-            .onStart {
-                mutex.withLock {
-                    bluetoothGatt?.connect() ?: run {
-                        bluetoothGatt = bluetoothDevice.connectGatt(
-                            context,
-                            autoConnect,
-                            callback,
-                            transport,
-                            phy, // Note: this have no effect when autoConnect is true
-                            null
-                        )
-                    }
-                }
-            }
-            .filterIsInstance()
-    }
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun discoverServices(): ServicesDiscovered {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("discoverServices") {
-                callback.events
-                    .onStart { it.discoverServices() }
-                    .filterIsInstance<ServicesDiscovered>()
-                    .firstOrNull() ?: ServicesDiscovered(BluetoothGatt.GATT_FAILURE)
-            }
-        } ?: ServicesDiscovered(BluetoothGatt.GATT_FAILURE)
-    }
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    private suspend fun updateNotifications(
-        characteristic: GattCharacteristic,
-        descriptor: UUID,
-        enable: Boolean
-    ): Boolean {
-        val value =
-            if (enable) BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE else BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
-        val targetDesc =
-            characteristic.descriptors.find { it.id == descriptor }?.bluetoothGattDescriptor
-        return (if (targetDesc != null) {
-            bluetoothGatt?.setCharacteristicNotification(
-                characteristic.bluetoothGattCharacteristic,
-                enable
-            )
-            mutex.queueWithTimeout("updateNotifications: $characteristic $descriptor $enable") {
-                callback.events
-                    .onStart {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            bluetoothGatt?.writeDescriptor(targetDesc, value)
-                        } else {
-                            targetDesc.value = value
-                            bluetoothGatt?.writeDescriptor(targetDesc)
-                        }
-                    }
-                    .filterIsInstance<DescriptorWritten>()
-                    .firstOrNull()
-                    ?: DescriptorWritten(
-                        characteristic,
-                        descriptor,
-                        BluetoothGatt.GATT_FAILURE
-                    )
-            }
-        } else {
-            DescriptorWritten(characteristic, descriptor, BluetoothGatt.GATT_FAILURE)
-        }).status == BluetoothGatt.GATT_SUCCESS
-    }
+    suspend fun discoverServices(): ServicesDiscovered
 
     @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
     suspend fun registerNotifications(
         characteristic: GattCharacteristic,
         descriptor: UUID = ClientCharacteristicConfigurationID
-    ): Boolean {
-        return updateNotifications(characteristic, descriptor, true)
-    }
+    ): Boolean
 
     @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
     suspend fun unregisterNotifications(
         characteristic: GattCharacteristic,
         descriptor: UUID = ClientCharacteristicConfigurationID
-    ): Boolean {
-        return updateNotifications(characteristic, descriptor, false)
-    }
-
+    ): Boolean
 
     /**
      * Write a new value to the specified GATT characteristic.
@@ -160,190 +67,278 @@ class GattDevice(
         characteristic: GattCharacteristic,
         value: ByteArray,
         writeType: Int = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT,
-    ): CharacteristicWritten {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("writeCharacteristic $characteristic ${value.size} bytes") {
-                callback.events
-                    .onStart {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            it.writeCharacteristic(
-                                characteristic.bluetoothGattCharacteristic,
-                                value,
-                                writeType
-                            )
-                        } else {
-                            characteristic.bluetoothGattCharacteristic.writeType = writeType
-                            characteristic.bluetoothGattCharacteristic.value = value
-                            it.writeCharacteristic(characteristic.bluetoothGattCharacteristic)
-                        }
-                    }
-                    .filterIsInstance<CharacteristicWritten>()
-                    .firstOrNull { it.characteristic.instanceId == characteristic.instanceId }
-                    ?: CharacteristicWritten(characteristic, BluetoothGatt.GATT_FAILURE)
-            }
-        } ?: CharacteristicWritten(characteristic, BluetoothGatt.GATT_FAILURE)
-    }
+    ): CharacteristicWritten
 
     /**
-     * Read from, a characteristic.
+     * Read from a characteristic.
      *
      * @param characteristic The characteristic to read from
      * @return The result of the read operation, including the value read if successful.
      */
     @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun readCharacteristic(characteristic: GattCharacteristic): CharacteristicRead {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("readCharacteristic $characteristic") {
-                callback.events
-                    .onStart { it.readCharacteristic(characteristic.bluetoothGattCharacteristic) }
-                    .filterIsInstance<CharacteristicRead>()
-                    .firstOrNull { it.characteristic.instanceId == characteristic.instanceId }
-                    ?: CharacteristicRead(
-                        characteristic,
-                        ByteArray(0),
-                        BluetoothGatt.GATT_FAILURE
-                    )
-            }
-        } ?: CharacteristicRead(characteristic, ByteArray(0), BluetoothGatt.GATT_FAILURE)
-    }
+    suspend fun readCharacteristic(characteristic: GattCharacteristic): CharacteristicRead
 
     @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
     suspend fun writeDescriptor(
         characteristic: GattCharacteristic,
         descriptor: GattDescriptor,
         value: ByteArray
-    ): DescriptorWritten {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("writeDescriptor $descriptor ${value.size}") {
-                callback.events
-                    .onStart {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            it.writeDescriptor(descriptor.bluetoothGattDescriptor, value)
-                        } else {
-                            descriptor.bluetoothGattDescriptor.value = value
-                            it.writeDescriptor(descriptor.bluetoothGattDescriptor)
-                        }
-                    }
-                    .filterIsInstance<DescriptorWritten>()
-                    .firstOrNull {
-                        it.descriptorId == descriptor.id
-                    } ?: DescriptorWritten(
-                    characteristic,
-                    descriptor.id,
-                    BluetoothGatt.GATT_FAILURE
-                )
-            }
-        } ?: DescriptorWritten(characteristic, descriptor.id, BluetoothGatt.GATT_FAILURE)
-    }
+    ): DescriptorWritten
 
     @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
     suspend fun readDescriptor(
         characteristic: GattCharacteristic,
         descriptor: GattDescriptor,
-    ): DescriptorRead {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("readDescriptor $characteristic $descriptor") {
-                callback.events
-                    .onStart { it.readDescriptor(descriptor.bluetoothGattDescriptor) }
-                    .filterIsInstance<DescriptorRead>()
-                    .firstOrNull {
-                        it.descriptor.id == descriptor.id &&
-                                it.characteristic.instanceId == characteristic.instanceId
-                    } ?: DescriptorRead(
-                    characteristic,
-                    descriptor,
-                    ByteArray(0),
-                    BluetoothGatt.GATT_FAILURE
-                )
+    ): DescriptorRead
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    suspend fun readMtu(mtu: Int): MtuChanged
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    suspend fun readPhy(): PhyRead
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    suspend fun setPreferredPhy(txPhy: Int, rxPhy: Int, phyOptions: Int): PhyUpdate
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    suspend fun readRemoteRssi(): ReadRemoteRssi
+}
+
+@SuppressLint("InlinedApi")
+@RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+fun ConnectedGattDevice(
+    scope: CoroutineScope,
+    bluetoothDevice: BluetoothDevice,
+    context: Context,
+    transport: Int = BluetoothDevice.TRANSPORT_LE,
+    phy: Int = BluetoothDevice.PHY_LE_1M,
+    eventBufferCapacity: Int = 10,
+    logger: ((level: Int, message: String, throwable: Throwable?) -> Unit) =
+        { _, _, _ -> },
+): GattDevice {
+    val (bluetoothGatt, gattEvents) = bluetoothDevice.connectGattIn(
+        context,
+        scope,
+        transport,
+        phy
+    )
+
+    return GattDeviceImpl(scope, bluetoothGatt, gattEvents, eventBufferCapacity, logger)
+}
+
+@SuppressLint("InlinedApi")
+internal class GattDeviceImpl(
+    scope: CoroutineScope,
+    private val bluetoothGatt: BluetoothGatt,
+    gattEvents: ReceiveChannel<GattEvent>,
+    eventBufferCapacity: Int,
+    private val logger: ((level: Int, message: String, throwable: Throwable?) -> Unit),
+) : GattDevice {
+    override val connectionState: StateFlow<ConnectionState>
+    override val services: StateFlow<List<GattService>>
+
+    /* :scream: */
+    private val eventBus = MutableSharedFlow<GattEvent>(extraBufferCapacity = eventBufferCapacity)
+    private val eventBusMutex = Mutex()
+
+    init {
+        connectionState = MutableStateFlow(ConnectionState.Disconnected)
+        services = MutableStateFlow(emptyList())
+
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            for (gattEvent in gattEvents) {
+                logEvent(gattEvent, logger)
+                when (gattEvent) {
+                    is ConnectionChanged -> connectionState.value = gattEvent.newState
+                    is ServicesDiscovered -> services.value =
+                        bluetoothGatt.services.map { GattService(it) }
+
+                    else -> {}
+                }
+                eventBus.emitOrThrow(gattEvent)
             }
-        } ?: DescriptorRead(
-            characteristic,
-            descriptor,
-            ByteArray(0),
-            BluetoothGatt.GATT_FAILURE
-        )
-    }
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun readMtu(mtu: Int): MtuChanged {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("requestMtu $mtu") {
-                callback.events
-                    .onStart { it.requestMtu(mtu) }
-                    .filterIsInstance<MtuChanged>()
-                    .firstOrNull()
-            }
-        } ?: MtuChanged(-1, BluetoothGatt.GATT_FAILURE)
-    }
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun readPhy(): PhyRead {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("readPhy") {
-                callback.events
-                    .onStart { it.readPhy() }
-                    .filterIsInstance<PhyRead>()
-                    .firstOrNull()
-            }
-        } ?: PhyRead(0, 0, BluetoothGatt.GATT_FAILURE)
-    }
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun setPreferredPhy(txPhy: Int, rxPhy: Int, phyOptions: Int): PhyUpdate {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("setPreferredPhy $txPhy $rxPhy $phyOptions") {
-                callback.events
-                    .onStart { it.setPreferredPhy(txPhy, rxPhy, phyOptions) }
-                    .filterIsInstance<PhyUpdate>()
-                    .firstOrNull()
-            }
-        } ?: PhyUpdate(0, 0, BluetoothGatt.GATT_FAILURE)
-    }
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun readRemoteRssi(): ReadRemoteRssi {
-        return bluetoothGatt?.let {
-            mutex.queueWithTimeout("readRemoteRssi") {
-                callback.events
-                    .onStart { it.readRemoteRssi() }
-                    .filterIsInstance<ReadRemoteRssi>()
-                    .firstOrNull()
-            }
-        } ?: ReadRemoteRssi(0, BluetoothGatt.GATT_FAILURE)
-    }
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun disconnect(): ConnectionChanged {
-        return mutex.queueWithTimeout("close") {
-            callback.events
-                .onStart { bluetoothGatt?.disconnect() }
-                .filterIsInstance<ConnectionChanged>()
-                .firstOrNull()
-        } ?: ConnectionChanged(BluetoothGatt.GATT_FAILURE, ConnectionState.Disconnected)
-    }
-
-    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
-    suspend fun close() {
-        mutex.withLock {
-            bluetoothGatt?.close()
-            bluetoothGatt = null
         }
     }
 
-    private suspend fun <T> Mutex.queueWithTimeout(
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun discoverServices(): ServicesDiscovered =
+        callGattDevice("discoverServices", { bluetoothGatt.discoverServices() }) {
+            it as? ServicesDiscovered
+        }
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun registerNotifications(
+        characteristic: GattCharacteristic,
+        descriptor: UUID
+    ): Boolean = updateNotifications(characteristic, descriptor, enable = true)
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun unregisterNotifications(
+        characteristic: GattCharacteristic,
+        descriptor: UUID
+    ): Boolean = updateNotifications(characteristic, descriptor, enable = false)
+
+    @Suppress("DEPRECATION")
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    private suspend fun updateNotifications(
+        characteristic: GattCharacteristic,
+        descriptor: UUID,
+        enable: Boolean
+    ): Boolean {
+        val value =
+            if (enable) BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE else BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+        val targetDesc =
+            characteristic.descriptors.find { it.id == descriptor }?.bluetoothGattDescriptor
+                ?: return false
+        val result = callGattDevice(
+            "updateNotifications: ${if (enable) "enable" else "disable"}",
+            {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    bluetoothGatt.writeDescriptor(targetDesc, value)
+                } else {
+                    targetDesc.value = value
+                    bluetoothGatt.writeDescriptor(targetDesc)
+                }
+            }
+        ) {
+            it as? DescriptorWritten
+        }
+
+        return result.status == BluetoothGatt.GATT_SUCCESS
+    }
+
+    @Suppress("DEPRECATION")
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun writeCharacteristic(
+        characteristic: GattCharacteristic,
+        value: ByteArray,
+        writeType: Int
+    ): CharacteristicWritten =
+        callGattDevice(
+            "writeCharacteristic",
+            {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    bluetoothGatt.writeCharacteristic(
+                        characteristic.bluetoothGattCharacteristic,
+                        value,
+                        writeType
+                    )
+                } else {
+                    characteristic.bluetoothGattCharacteristic.writeType = writeType
+                    characteristic.bluetoothGattCharacteristic.value = value
+                    bluetoothGatt.writeCharacteristic(characteristic.bluetoothGattCharacteristic)
+                }
+            }
+        ) {
+            (it as? CharacteristicWritten)?.takeIf {
+                it.characteristic.instanceId == characteristic.instanceId
+            }
+        }
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun readCharacteristic(characteristic: GattCharacteristic): CharacteristicRead =
+        callGattDevice(
+            "readCharacteristic",
+            { bluetoothGatt.readCharacteristic(characteristic.bluetoothGattCharacteristic) }
+        ) {
+            (it as? CharacteristicRead)?.takeIf {
+                it.characteristic.instanceId == characteristic.instanceId
+            }
+        }
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun writeDescriptor(
+        characteristic: GattCharacteristic,
+        descriptor: GattDescriptor,
+        value: ByteArray
+    ): DescriptorWritten =
+        callGattDevice(
+            "writeDescriptor",
+            {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    bluetoothGatt.writeDescriptor(descriptor.bluetoothGattDescriptor, value)
+                } else {
+                    descriptor.bluetoothGattDescriptor.value = value
+                    bluetoothGatt.writeDescriptor(descriptor.bluetoothGattDescriptor)
+                }
+
+            }
+        ) {
+            (it as? DescriptorWritten)?.takeIf { it.descriptorId == descriptor.id }
+        }
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun readDescriptor(
+        characteristic: GattCharacteristic,
+        descriptor: GattDescriptor
+    ): DescriptorRead =
+        callGattDevice("readDescriptor", { bluetoothGatt.readDescriptor(descriptor.bluetoothGattDescriptor) }) {
+            (it as? DescriptorRead)?.takeIf {
+                it.descriptor.id == descriptor.id &&
+                        it.characteristic.instanceId == characteristic.instanceId
+            }
+        }
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun readMtu(mtu: Int): MtuChanged =
+        callGattDevice("readMtu", { bluetoothGatt.requestMtu(mtu) }) { it as? MtuChanged }
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun readPhy(): PhyRead =
+        callGattDevice("readPhy", { bluetoothGatt.readPhy() }) { it as? PhyRead }
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun setPreferredPhy(txPhy: Int, rxPhy: Int, phyOptions: Int): PhyUpdate =
+        callGattDevice("setPreferredPhy", { bluetoothGatt.setPreferredPhy(txPhy, rxPhy, phyOptions) }) {
+            it as? PhyUpdate
+        }
+
+    @RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+    override suspend fun readRemoteRssi(): ReadRemoteRssi =
+        callGattDevice("readRemoteRssi", { bluetoothGatt.readRemoteRssi() }) { it as? ReadRemoteRssi }
+
+    private suspend fun <T : GattEvent> callGattDevice(
         action: String,
-        timeout: Long = DEFAULT_GATT_TIMEOUT,
-        block: suspend CoroutineScope.() -> T
-    ): T {
-        return try {
-            logger?.invoke(Log.DEBUG, "try: $action", null)
-            withLock {
-                return@withLock withTimeout(timeMillis = timeout, block = block)
+        gattCall: () -> Unit,
+        filter: (GattEvent) -> T?
+    ): T = eventBusMutex.withLock {
+        withTimeoutOrNull(DEFAULT_GATT_TIMEOUT) {
+            try {
+                connectionState.first { it == ConnectionState.Connected }
+                eventBus
+                    .onStart {
+                        logger(Log.DEBUG, "try: $action", null)
+                        gattCall()
+                    }
+                    .mapNotNull { filter(it) }
+                    .first()
+            } catch (e: Exception) {
+                logger(Log.ERROR, "error: $action", null)
+                throw e
             }
-        } catch (e: Exception) {
-            logger?.invoke(Log.ERROR, "error: $action", null)
-            throw e
+        } ?: throw IllegalStateException("Gatt timeout")
+    }
+
+    private fun logEvent(
+        event: GattEvent,
+        logger: ((level: Int, message: String, throwable: Throwable?) -> Unit)
+    ) {
+        val desc = when (event) {
+            is ServicesDiscovered -> "onServicesDiscovered"
+            is CharacteristicRead -> "onCharacteristicRead"
+            is CharacteristicWritten -> "onCharacteristicWritten"
+            is DescriptorRead -> "onDescriptorRead"
+            is DescriptorWritten -> "onDescriptorWritten"
+            is MtuChanged -> "onMtuChanged"
+            is PhyRead -> "onPhyRead"
+            is PhyUpdate -> "onPhyUpdate"
+            is ReadRemoteRssi -> "onReadRemoteRssi"
+            else -> "onUnknownEvent"
         }
+        logger(Log.INFO, "$desc: $event", null)
     }
 }
 
+private fun <T> MutableSharedFlow<T>.emitOrThrow(item: T) {
+    if (!tryEmit(item)) throw IllegalStateException("Buffer overflow")
+}

--- a/blex/src/main/java/se/hellsoft/blex/bluetoothDevice.kt
+++ b/blex/src/main/java/se/hellsoft/blex/bluetoothDevice.kt
@@ -1,0 +1,94 @@
+package se.hellsoft.blex
+
+import android.Manifest.permission.BLUETOOTH
+import android.Manifest.permission.BLUETOOTH_CONNECT
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.content.Context
+import androidx.annotation.RequiresPermission
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Connects to a BluetoothGatt in a managed fashion, exposing all events as a [ReceiveChannel]
+ * to ensure that all events are handled.
+ *
+ * The connection to the [BluetoothGatt] is managed within the [CoroutineScope], and will be
+ * disconnected and closed upon cancellation.
+ */
+@SuppressLint("InlinedApi")
+@RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+internal fun BluetoothDevice.connectGattIn(
+    context: Context,
+    coroutineScope: CoroutineScope,
+    transport: Int = BluetoothDevice.TRANSPORT_LE,
+    phy: Int = BluetoothDevice.PHY_LE_1M,
+): Pair<BluetoothGatt, ReceiveChannel<GattEvent>> {
+    lateinit var bluetoothGatt: BluetoothGatt
+    val callback = ChannelBluetoothGattCallback()
+
+    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        suspendCancellableCoroutine<Nothing> { continuation ->
+            bluetoothGatt = this@connectGattIn.connectGatt(
+                /* context */ context,
+                /* autoConnect */ true,
+                /* callback */
+                callback,
+                /* transport */ transport,
+                /* phy */ phy,
+                /* handler */ null,
+            )
+
+            continuation.invokeOnCancellation { 
+                bluetoothGatt.disconnect()
+                bluetoothGatt.close()
+            }
+        }
+    }
+
+    return bluetoothGatt to callback.receiveEvents
+}
+
+/**
+ * Runs a block of code with a managed GATT connection to this [BluetoothDevice].
+ *
+ * A connection will be created to this [BluetoothDevice], and torn down at the end of [block] by
+ * calling [BluetoothGatt.disconnect] and [BluetoothGatt.close]
+ */
+@SuppressLint("InlinedApi")
+@RequiresPermission(anyOf = [BLUETOOTH, BLUETOOTH_CONNECT])
+suspend fun BluetoothDevice.withGattConnection(
+    context: Context,
+    transport: Int = BluetoothDevice.TRANSPORT_LE,
+    phy: Int = BluetoothDevice.PHY_LE_1M,
+    eventBufferCapacity: Int = 10,
+    logger: ((level: Int, message: String, throwable: Throwable?) -> Unit) =
+        { _, _, _ -> },
+    block: suspend GattDevice.() -> Unit,
+) = coroutineScope {
+    val bluetoothJob = Job(coroutineContext[Job])
+    val bluetoothScope = this + bluetoothJob
+
+    val gattDevice = ConnectedGattDevice(
+        bluetoothScope,
+        this@withGattConnection,
+        context,
+        transport,
+        phy,
+        eventBufferCapacity,
+        logger,
+    )
+
+    gattDevice.block()
+
+    bluetoothJob.cancelAndJoin()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0-beta05' apply false
-    id 'com.android.library' version '7.4.0-beta05' apply false
+    id 'com.android.application' version '7.3.0' apply false
+    id 'com.android.library' version '7.3.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }


### PR DESCRIPTION
Big ideas here:

* A `GattDevice` instance is only ever intended to be connected. This clarifies the expected results of pretty much every API call: because the instance only ever seeks a connected state, it's not possible to make a call that's guaranteed to fail
* All gatt functions are non-nullable, and will throw on timeout
* All gatt functions await a connected state before sending their commands in order to avoid dropping commands
* As a result of the above two changes, no artificially constructed `GATT_FAILURE` results are ever received: any `GATT_FAILURE` must come from the device
* The underlying connections to the `BluetoothGatt` instance are managed via processes running in a `CoroutineScope`. Upon cancellation, those processes will automatically clean up the `BluetoothGatt` connection by calling `disconnect` and `close`
